### PR TITLE
🎃 Hacktoberfest 2025: Remove GitHub Stars from stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,5 @@
   <img src="https://img.shields.io/badge/Projects-100-blue?style=for-the-badge" />
   <img src="https://img.shields.io/badge/Languages-12-green?style=for-the-badge" />
   <img src="https://img.shields.io/badge/Live%20Sites-25-orange?style=for-the-badge" />
-  <img src="https://img.shields.io/badge/GitHub%20Stars-11-yellow?style=for-the-badge" />
 </p>
 

--- a/sync-readme.js
+++ b/sync-readme.js
@@ -151,7 +151,6 @@ function generateStatsSection(projects) {
   const totalProjects = projects.length;
   const languages = new Set(projects.map(p => p.language).filter(Boolean)).size;
   const liveProjects = projects.filter(p => p.live || p.netlify_live).length;
-  const totalStars = projects.reduce((sum, p) => sum + (p.stars || 0), 0);
 
   return `---
 
@@ -161,7 +160,6 @@ function generateStatsSection(projects) {
   <img src="https://img.shields.io/badge/Projects-${totalProjects}-blue?style=for-the-badge" />
   <img src="https://img.shields.io/badge/Languages-${languages}-green?style=for-the-badge" />
   <img src="https://img.shields.io/badge/Live%20Sites-${liveProjects}-orange?style=for-the-badge" />
-  <img src="https://img.shields.io/badge/GitHub%20Stars-${totalStars}-yellow?style=for-the-badge" />
 </p>
 
 `;


### PR DESCRIPTION
- Remove GitHub Stars badge from stats section
- Keep clean focus on Projects, Languages, and Live Sites
- Part of profile enhancement improvements
- Preparing for Hacktoberfest contribution

#hacktoberfest #hacktoberfest2025